### PR TITLE
Allow telekit to call teleapi with custom API's

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -19,7 +19,7 @@ class Telekit extends Basic {
         super();
 
         /** Create API instance with help of teleapi */
-        const API = teleapi(options.token);
+        const API = teleapi(options.token, options.api || undefined);
 
         /** Options */
         this.options = options;


### PR DESCRIPTION
If user passes it's own API object to telekit - teleapi instance with this api will be created rather than default.